### PR TITLE
Updated DVL models to include current profiling field (for plugin)

### DIFF
--- a/launch/whoi_current_profiling_demo.launch
+++ b/launch/whoi_current_profiling_demo.launch
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="gui" default="true"/>
+  <arg name="paused" default="false"/>
+  <arg name="world_name" default="$(find nps_uw_sensors_gazebo)/worlds/ocean_waves_watch_whoi_dvl.world"/>
+
+  <!-- use Gazebo's empty_world.launch with uuv_dave_ocean_waves.world -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="$(arg world_name)"/>
+    <arg name="extra_gazebo_args" value="-s libdsros_sensors.so"/>
+    <arg name="paused" value="$(arg paused)"/>
+    <arg name="use_sim_time" value="true"/>
+    <arg name="gui" value="$(arg gui)"/>
+    <arg name="headless" value="false"/>
+    <arg name="debug" value="false"/>
+    <arg name="verbose" value="false"/>
+  </include>
+
+  <!-- Load and spawn the model, starts the joint & state publishers, make the model move -->
+  <param name="model_name" type="str" value="whoi_teledyne_whn"/>
+  <param name="base_link_name" type="str" value="whn_base_link"/>
+</launch>

--- a/models/whoi_nortek_dvl1000_300/model.sdf
+++ b/models/whoi_nortek_dvl1000_300/model.sdf
@@ -41,6 +41,7 @@
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_nortek_dvl1000_300/model.sdf
+++ b/models/whoi_nortek_dvl1000_300/model.sdf
@@ -42,6 +42,7 @@
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_nortek_dvl1000_4000/model.sdf
+++ b/models/whoi_nortek_dvl1000_4000/model.sdf
@@ -41,6 +41,7 @@
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_nortek_dvl1000_4000/model.sdf
+++ b/models/whoi_nortek_dvl1000_4000/model.sdf
@@ -42,6 +42,7 @@
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_nortek_dvl500_300/model.sdf
+++ b/models/whoi_nortek_dvl500_300/model.sdf
@@ -41,6 +41,7 @@
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_nortek_dvl500_300/model.sdf
+++ b/models/whoi_nortek_dvl500_300/model.sdf
@@ -42,6 +42,7 @@
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_nortek_dvl500_6000/model.sdf
+++ b/models/whoi_nortek_dvl500_6000/model.sdf
@@ -41,6 +41,7 @@
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_nortek_dvl500_6000/model.sdf
+++ b/models/whoi_nortek_dvl500_6000/model.sdf
@@ -42,6 +42,7 @@
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_sonardyne_syrinx600/model.sdf
+++ b/models/whoi_sonardyne_syrinx600/model.sdf
@@ -41,6 +41,7 @@
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_sonardyne_syrinx600/model.sdf
+++ b/models/whoi_sonardyne_syrinx600/model.sdf
@@ -42,6 +42,7 @@
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_teledyne_explorer1000/model.sdf
+++ b/models/whoi_teledyne_explorer1000/model.sdf
@@ -41,6 +41,7 @@
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_teledyne_explorer1000/model.sdf
+++ b/models/whoi_teledyne_explorer1000/model.sdf
@@ -40,6 +40,7 @@
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_teledyne_explorer4000/model.sdf
+++ b/models/whoi_teledyne_explorer4000/model.sdf
@@ -41,6 +41,7 @@
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_teledyne_explorer4000/model.sdf
+++ b/models/whoi_teledyne_explorer4000/model.sdf
@@ -42,6 +42,7 @@
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>1</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_teledyne_whn/model.sdf
+++ b/models/whoi_teledyne_whn/model.sdf
@@ -40,6 +40,7 @@
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>false</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/models/whoi_teledyne_whn/model.sdf
+++ b/models/whoi_teledyne_whn/model.sdf
@@ -41,6 +41,7 @@
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>false</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_nortek_dvl1000_300.xacro
+++ b/urdf/whoi_nortek_dvl1000_300.xacro
@@ -98,6 +98,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_nortek_dvl1000_300.xacro
+++ b/urdf/whoi_nortek_dvl1000_300.xacro
@@ -97,6 +97,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_nortek_dvl1000_4000.xacro
+++ b/urdf/whoi_nortek_dvl1000_4000.xacro
@@ -97,6 +97,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_nortek_dvl1000_4000.xacro
+++ b/urdf/whoi_nortek_dvl1000_4000.xacro
@@ -96,6 +96,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_nortek_dvl500_300.xacro
+++ b/urdf/whoi_nortek_dvl500_300.xacro
@@ -98,6 +98,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_nortek_dvl500_300.xacro
+++ b/urdf/whoi_nortek_dvl500_300.xacro
@@ -97,6 +97,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_nortek_dvl500_6000.xacro
+++ b/urdf/whoi_nortek_dvl500_6000.xacro
@@ -98,6 +98,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_nortek_dvl500_6000.xacro
+++ b/urdf/whoi_nortek_dvl500_6000.xacro
@@ -97,6 +97,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_sonardyne_syrinx600.xacro
+++ b/urdf/whoi_sonardyne_syrinx600.xacro
@@ -98,6 +98,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_sonardyne_syrinx600.xacro
+++ b/urdf/whoi_sonardyne_syrinx600.xacro
@@ -97,6 +97,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_teledyne_explorer_1000.xacro
+++ b/urdf/whoi_teledyne_explorer_1000.xacro
@@ -98,6 +98,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_teledyne_explorer_1000.xacro
+++ b/urdf/whoi_teledyne_explorer_1000.xacro
@@ -97,6 +97,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_teledyne_explorer_4000.xacro
+++ b/urdf/whoi_teledyne_explorer_4000.xacro
@@ -98,6 +98,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_teledyne_explorer_4000.xacro
+++ b/urdf/whoi_teledyne_explorer_4000.xacro
@@ -97,6 +97,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_teledyne_whn.xacro
+++ b/urdf/whoi_teledyne_whn.xacro
@@ -96,6 +96,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
           <waterTrackBins>10</waterTrackBins>
+          <currentProfileCoordMode>0</currentProfileCoordMode>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_teledyne_whn.xacro
+++ b/urdf/whoi_teledyne_whn.xacro
@@ -95,6 +95,7 @@ POSSIBILITY OF SUCH DAMAGE.
           <beamAzimuthDeg3>45</beamAzimuthDeg3>
           <beamAzimuthDeg4>-45</beamAzimuthDeg4>
           <enableWaterTrack>1</enableWaterTrack>
+          <waterTrackBins>10</waterTrackBins>
           <pos_z_down>true</pos_z_down>
           <collide_bitmask>0x0001</collide_bitmask>
         </plugin>

--- a/urdf/whoi_teledyne_whn_robot.xacro
+++ b/urdf/whoi_teledyne_whn_robot.xacro
@@ -8,12 +8,13 @@
 
   <link name="robot_link">
     <inertial>
+      <!-- These are RexROV values to align with hydrodynamic model -->
       <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="200"/>
+      <mass value="1862.87"/>
       <inertia
-        ixx="96.67" ixy="0.0" ixz="0.0"
-        iyy="158.17" iyz="0.0"
-        izz="146.83"/>
+        ixx="525.39" ixy="1.44" ixz="33.41"
+        iyy="794.20" iyz="2.6"
+        izz="691.23"/>
     </inertial>
     <visual>
       <geometry>
@@ -28,6 +29,44 @@
       <origin xyz="-0.1 0 0.5" rpy="0 0 0"/>
     </collision>
   </link>
+  <gazebo>
+    <plugin name="uuv_plugin" filename="libuuv_underwater_object_ros_plugin.so">
+      <fluid_density>1028.0</fluid_density>
+      <flow_velocity_topic>hydrodynamics/current_velocity</flow_velocity_topic>
+      <debug>0</debug>
+      <!-- Adding the hydrodynamic and hydrostatic parameters for the vehicle-->
+      <link name="robot_link">
+        <neutrally_buoyant>0</neutrally_buoyant>
+        <volume>1.83826</volume>
+        <box>
+          <width>1.6</width>
+          <length>2.5</length>
+          <height>1.6</height>
+        </box>
+        <center_of_buoyancy>0.0 0.0 0.3</center_of_buoyancy>
+        <hydrodynamic_model>
+          <type>fossen</type>
+          <!-- Added mass: see p.28 in Berg2012 -->
+          <added_mass>
+             779.79 -6.8773 -103.32  8.5426 -165.54 -7.8033
+            -6.8773    1222   51.29  409.44 -5.8488  62.726
+            -103.32   51.29  3659.9  6.1112 -386.42  10.774
+            8.5426  409.44  6.1112   534.9 -10.027  21.019
+            -165.54 -5.8488 -386.42 -10.027  842.69 -1.1162
+            -7.8033  62.726  10.775  21.019 -1.1162  224.32
+          </added_mass>
+          <!-- Linear damping: see p.31 in Berg2012 -->
+          <linear_damping>
+            -74.82 -69.48 -728.4 -268.8 -309.77 -105
+          </linear_damping>
+          <!-- Non-linear damping: see p.30 in Berg2012 -->
+          <quadratic_damping>
+            -748.22 -992.53 -1821.01 -672 -774.44 -523.27
+          </quadratic_damping>
+        </hydrodynamic_model>
+      </link>
+    </plugin>
+  </gazebo>
 
   <joint name="robot_base_joint" type="fixed">
     <origin xyz="0 0 0" rpy="0 0 0"/>  <!-- X-fwd, Y-lft, Z-up (ick!) -->


### PR DESCRIPTION
Insignificant commit for the most part--I added a waterTrackBins field to the DVL models in support of the current profiling incorporation into the WHOI DSL plugin.  If you use the latest nps_dev branch from our copy of the WHOI DSL repos (ds_msgs and ds_sim) and run any of the DVL demos (e.g., roslaunch nps_uw_sensors whoi_teledyne_whn.launch) you'll get the current profile messages (rostopic echo dvl/dvl_current).  

You'll still get the messages without merging this pull request, but the plugin will default to 1 bin (I think I put 10 in all of the models).