### PR TITLE
Noetic Compatibility: Gazebo 11 & python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,19 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(nps_uw_sensors_gazebo)
 
+## Compile as C++11, supported in ROS Kinetic and newer
+# If running on focal, will be using Noetic + Gazebo11, which requires c++17
+execute_process(COMMAND lsb_release -cs
+  OUTPUT_VARIABLE RELEASE_CODENAME
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(RELEASE_CODENAME MATCHES "focal")
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+else()
+  add_compile_options(-std=c++11)
+endif()
+
 find_package(catkin REQUIRED tf gazebo_plugins)
 
 find_package(gazebo REQUIRED)
@@ -11,7 +24,7 @@ include_directories(${roscpp_INCLUDE_DIRS})
 include_directories(${std_msgs_INCLUDE_DIRS})
 include_directories(
   include
-  ${catkin_INCLUDE_DIRS} 
+  ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
 )
 link_directories(${GAZEBO_LIBRARY_DIRS})
@@ -22,10 +35,10 @@ catkin_package()
 ## Plugins
 
 add_library(gazebo_ros_pulse_lidar_plugin src/gazebo_ros_pulse_lidar.cpp)
-target_link_libraries(gazebo_ros_pulse_lidar_plugin 
+target_link_libraries(gazebo_ros_pulse_lidar_plugin
                       ${GAZEBO_LIBRARIES} ${roscpp_LIBRARIES})
 
-add_library(nps_gazebo_ros_gpu_sonar_single_beam_plugin 
+add_library(nps_gazebo_ros_gpu_sonar_single_beam_plugin
             src/nps_gazebo_ros_gpu_sonar_single_beam.cpp)
 target_link_libraries(nps_gazebo_ros_gpu_sonar_single_beam_plugin
                       GpuRayPlugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,5 +55,8 @@ install(DIRECTORY launch
         PATTERN "*~" EXCLUDE)
 
 # for Python scripts
-catkin_install_python(PROGRAMS scripts/depth_camera_sonar.py
+catkin_install_python(PROGRAMS
+  scripts/depth_camera_sonar.py
+  src/simple_box_motion.py
+  src/simple_motion.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
Minor changes to be able to run demos in Noetic.

* use c++17 if running on Focal (since Gazebo11 requires c++17). The same fix was merged here: https://github.com/Field-Robotics-Lab/dave/pull/75 
* add python scripts used in demo launch files to catkin_install_python so their shebang lines will be properly overwritten 

NB: This is NOT a complete port, I'm just fixing issues as I stumble across them.