### PR TITLE
Noetic compatibility: Add scripts to catkin_install_python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,5 +42,8 @@ install(DIRECTORY launch
         PATTERN "*~" EXCLUDE)
 
 # for Python scripts
-catkin_install_python(PROGRAMS scripts/depth_camera_sonar.py
+catkin_install_python(PROGRAMS
+  scripts/depth_camera_sonar.py
+  src/simple_box_motion.py
+  src/simple_motion.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
Add python scripts used in demo launch files to catkin_install_python so their shebang lines will be properly overwritten.

(A little more info is in section 1.3 of this wiki page: http://wiki.ros.org/UsingPython3/SourceCodeChanges)