### PR TITLE
Changing message type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ enable_language(CUDA CXX)
 find_package(catkin REQUIRED COMPONENTS
  tf
  gazebo_plugins
- frl_sensor_msgs)
+ frl_sensor_msgs
+ imaging_sonar_msgs)
 
 find_package(gazebo REQUIRED)
 find_package(roscpp REQUIRED)
@@ -42,6 +43,7 @@ catkin_package(
   LIBRARIES
   CATKIN_DEPENDS
   frl_sensor_msgs
+  imaging_sonar_msgs
  )
 
 ## Plugins

--- a/include/nps_uw_sensors_gazebo/gazebo_ros_image_sonar.hh
+++ b/include/nps_uw_sensors_gazebo/gazebo_ros_image_sonar.hh
@@ -49,7 +49,7 @@
 #include <sensor_msgs/fill_image.h>
 #include <std_msgs/Float64.h>
 #include <image_transport/image_transport.h>
-#include <frl_sensor_msgs/SonarImage.h>
+#include <imaging_sonar_msgs/SonarImage.h>
 
 // dynamic reconfigure stuff
 #include <gazebo_plugins/GazeboRosCameraConfig.h>
@@ -173,7 +173,7 @@ namespace gazebo
 
     private: sensor_msgs::Image depth_image_msg_;
     private: sensor_msgs::PointCloud2 point_cloud_msg_;
-    private: frl_sensor_msgs::SonarImage sonar_image_msg_;
+    private: imaging_sonar_msgs::SonarImage sonar_image_msg_;
     private: cv::Mat point_cloud_image_;
 
     std::default_random_engine generator;

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,8 @@
   <depend>uuv_sensor_ros_plugins</depend>
   <depend>gazebo_msgs</depend>
   <depend>sensor_msgs</depend>
+  <!-- From https://gitlab.com/apl-ocean-engineering/imaging_sonar_msgs -->
+  <depend>imaging_sonar_msgs</depend>
   <depend>frl_sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>roscpp</depend>

--- a/src/gazebo_ros_image_sonar.cpp
+++ b/src/gazebo_ros_image_sonar.cpp
@@ -348,7 +348,7 @@ void NpsGazeboRosImageSonar::Advertise()
 
   // Publisher for sonar image
   this->sonar_image_pub_ =
-      this->rosnode_->advertise<frl_sensor_msgs::SonarImage>
+      this->rosnode_->advertise<imaging_sonar_msgs::SonarImage>
       ("sonar_image", 10);
 }
 


### PR DESCRIPTION
Changes the imaging sonar message type to be from the APL imaging_sonar_msgs package.

Instead of using a message definition copied over, let's use the original message definition in-place.  This adds a dependency, but avoids maintaining two very similar message definitions.
