### PR TITLE
Add OpenCV include directories in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(gazebo REQUIRED)
 find_package(roscpp REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(OpenCV)
+find_package(OpenCV REQUIRED)
 
 find_package(CUDA REQUIRED)
 include_directories(${CUDA_INCLUDE_DIRS})
@@ -30,6 +30,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch=sm_60")
 
 include_directories(${roscpp_INCLUDE_DIRS})
 include_directories(${std_msgs_INCLUDE_DIRS})
+include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}


### PR DESCRIPTION
When I tried to run `catkin build` after the most recent changes, I got the error:
~~~
/home/lindzey/dave_ws/src/nps_uw_sensors_gazebo/include/nps_uw_sensors_gazebo/sonar_calculation_cuda.cuh:30:10: fatal error: opencv2/core.hpp: No such file or directory
   30 | #include <opencv2/core.hpp>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
~~~

Adding the OpenCV_INCLUDE_DIRS that are found by `find_package(OpenCV)` fixed this problem for me (Noetic, Ubuntu 20.04).