### PR TITLE
Use sonar_image_connect_count_ when deciding whether to publish SonarImage.msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(gazebo REQUIRED)
 find_package(roscpp REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(OpenCV)
+find_package(OpenCV REQUIRED)
 
 find_package(CUDA REQUIRED)
 include_directories(${CUDA_INCLUDE_DIRS})
@@ -30,6 +30,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch=sm_60")
 
 include_directories(${roscpp_INCLUDE_DIRS})
 include_directories(${std_msgs_INCLUDE_DIRS})
+include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}

--- a/src/gazebo_ros_image_sonar.cpp
+++ b/src/gazebo_ros_image_sonar.cpp
@@ -489,6 +489,7 @@ void NpsGazeboRosImageSonar::OnNewDepthFrame(const float *_image,
     // Deactivate if no subscribers
     if (this->depth_image_connect_count_ <= 0 &&
         this->point_cloud_connect_count_ <= 0 &&
+        this->sonar_image_connect_count_ <= 0 &&
         (*this->image_connect_count_) <= 0)
     {
       this->parentSensor->SetActive(false);
@@ -500,7 +501,8 @@ void NpsGazeboRosImageSonar::OnNewDepthFrame(const float *_image,
       this->ComputePointCloud(_image);
 
       // Generate sonar image data if topics have subscribers
-      if (this->depth_image_connect_count_ > 0)
+      if (this->depth_image_connect_count_ > 0 ||
+          this->sonar_image_connect_count_ > 0) {
         this->ComputeSonarImage(_image);
     }
   }


### PR DESCRIPTION
I ran into issues with this plugin properly activating/deactivating based on subscriptions to its published topics. 

I stopped debugging when I fixed enough of the problem to have a workaround, so maybe consider this PR to be a bug report with a partial fix attached =) (This PR builds on #36, though I'd recommend merging #36 and doing your own more comprehensive fix for this issue.)

I am using a modified version of the recommended launch file:
`roslaunch nps_uw_sensors_gazebo sonar_tank_blueview_p900.launch verbose:=true`
The perspective file for rqt_gui gave me errors on Ubuntu 20.04, so I'm running with it commented out.

However, with this setup, I wasn't seeing any images in rqt_image_view, and neither
`rostopic echo -n 1 /blueview_p900/sonar_image_raw` nor `rostopic echo -n 1 /blueview_p900/sonar_image` yielded any data. 

After a bit of digging, I discovered that `sonar_image_connect_count_` wasn't being used in the decision of whether to publish the sonar image; this PR fixes it for sonar_image_raw.

However, it does NOT fix these additional issues that I found:

* subscribing to /blueview_p900/sonar_image in isolation doesn't trigger sonar image calculation
* unsubscribing from everything does not actually cause OnNewDepthFrame to stop being called