### PR TITLE
Fix intensity conversion for SonarImage.msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(gazebo REQUIRED)
 find_package(roscpp REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(OpenCV)
+find_package(OpenCV REQUIRED)
 
 find_package(CUDA REQUIRED)
 include_directories(${CUDA_INCLUDE_DIRS})
@@ -30,6 +30,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch=sm_60")
 
 include_directories(${roscpp_INCLUDE_DIRS})
 include_directories(${std_msgs_INCLUDE_DIRS})
+include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}

--- a/src/gazebo_ros_image_sonar.cpp
+++ b/src/gazebo_ros_image_sonar.cpp
@@ -394,10 +394,6 @@ void NpsGazeboRosImageSonar::Advertise()
       boost::bind(&NpsGazeboRosImageSonar::SonarImageDisconnect, this),
       ros::VoidPtr(), &this->camera_queue_);
   this->sonar_image_pub_ = this->rosnode_->advertise(sonar_image_ao);
-
-  this->sonar_image_pub_ =
-      this->rosnode_->advertise<sensor_msgs::Image>
-      ("sonar_image", 10);
 }
 
 

--- a/src/gazebo_ros_image_sonar.cpp
+++ b/src/gazebo_ros_image_sonar.cpp
@@ -489,6 +489,7 @@ void NpsGazeboRosImageSonar::OnNewDepthFrame(const float *_image,
     // Deactivate if no subscribers
     if (this->depth_image_connect_count_ <= 0 &&
         this->point_cloud_connect_count_ <= 0 &&
+        this->sonar_image_connect_count_ <= 0 &&
         (*this->image_connect_count_) <= 0)
     {
       this->parentSensor->SetActive(false);
@@ -500,7 +501,8 @@ void NpsGazeboRosImageSonar::OnNewDepthFrame(const float *_image,
       this->ComputePointCloud(_image);
 
       // Generate sonar image data if topics have subscribers
-      if (this->depth_image_connect_count_ > 0)
+      if (this->depth_image_connect_count_ > 0 ||
+          this->sonar_image_connect_count_ > 0) {
         this->ComputeSonarImage(_image);
     }
   }

--- a/src/gazebo_ros_image_sonar.cpp
+++ b/src/gazebo_ros_image_sonar.cpp
@@ -679,9 +679,14 @@ void NpsGazeboRosImageSonar::ComputeSonarImage(const float *_src)
   this->sonar_image_raw_msg_.data_size = 1;  // sizeof(float) * nFreq * nBeams;
   std::vector<uchar> intensities;
   for (size_t f = 0; f < nFreq; f ++)
+  {
     for (size_t beam = 0; beam < nBeams; beam ++)
-      intensities.push_back(
-          static_cast<uchar>(static_cast<int>(abs(P_Beams[beam][f]))));
+    {
+      int intensity = static_cast<int>(sensor_gain * abs(P_Beams[beam][f]));
+      uchar counts = static_cast<uchar>(std::min(UCHAR_MAX, intensity));
+      intensities.push_back(counts);
+    }
+  }
   this->sonar_image_raw_msg_.intensities = intensities;
 
   this->sonar_image_raw_pub_.publish(this->sonar_image_raw_msg_);

--- a/src/gazebo_ros_image_sonar.cpp
+++ b/src/gazebo_ros_image_sonar.cpp
@@ -504,6 +504,7 @@ void NpsGazeboRosImageSonar::OnNewDepthFrame(const float *_image,
       if (this->depth_image_connect_count_ > 0 ||
           this->sonar_image_connect_count_ > 0) {
         this->ComputeSonarImage(_image);
+      }
     }
   }
   else

--- a/src/gazebo_ros_image_sonar.cpp
+++ b/src/gazebo_ros_image_sonar.cpp
@@ -678,6 +678,7 @@ void NpsGazeboRosImageSonar::ComputeSonarImage(const float *_src)
   // this->sonar_image_raw_msg_.is_bigendian = false;
   this->sonar_image_raw_msg_.data_size = 1;  // sizeof(float) * nFreq * nBeams;
   std::vector<uchar> intensities;
+  float sensor_gain = 0.02;
   for (size_t f = 0; f < nFreq; f ++)
   {
     for (size_t beam = 0; beam < nBeams; beam ++)


### PR DESCRIPTION
DO NOT MERGE -- this is another one of those "bug report with code sample attached" PRs. 

The problem with the SonarImage.msg's display was due to how the intensities were converted to uchars.

The message was designed assuming that the sonar instrument would do some amount of onboard processing, and output the final intensity as "counts" in the range of [0-255] or [0-65535].

The original version of this code was reporting `intensity%256`, rather than `min(255, intensity)`

The conversion to counts from whatever units are used to represent the complex signal in for the sonar processing is going to be instrument and configuration dependent. Right now, this PR just has a magic number for the gain, but I assume that you'll want that to be a parameter of some sort. 


**Before**:
<img width="400" alt="Screen Shot 2020-12-18 at 7 02 48 PM" src="https://user-images.githubusercontent.com/65185744/102679306-b342cf80-4163-11eb-976b-1687ef33a6dc.png">

**After**:
<img width="400" alt="Screen Shot 2020-12-18 at 7 02 14 PM" src="https://user-images.githubusercontent.com/65185744/102679305-ade58500-4163-11eb-87bf-516ca3486778.png">

