### PR TITLE
[Branch on origin repo for #37 and #38] Fix sonar connect count and Sensor gain handle

### DIFF
--- a/include/nps_uw_sensors_gazebo/gazebo_ros_image_sonar.hh
+++ b/include/nps_uw_sensors_gazebo/gazebo_ros_image_sonar.hh
@@ -152,10 +152,6 @@ namespace gazebo
     private: void NormalImageDisconnect();
     private: void PointCloudConnect();
     private: void PointCloudDisconnect();
-    private: void SonarImageConnect();
-    private: void SonarImageDisconnect();
-    private: void SonarImageRawConnect();
-    private: void SonarImageRawDisconnect();
     private: common::Time last_depth_image_camera_info_update_time_;
 
     /// \brief A pointer to the ROS node.
@@ -203,7 +199,6 @@ namespace gazebo
     private: event::ConnectionPtr newDepthFrameConnection;
     private: event::ConnectionPtr newImageFrameConnection;
     private: event::ConnectionPtr newRGBPointCloudConnection;
-    private: event::ConnectionPtr newSonarImageConnection;
 
     // A couple of "convenience" functions for computing azimuth & elevation
     private: inline double Azimuth(int col)

--- a/include/nps_uw_sensors_gazebo/gazebo_ros_image_sonar.hh
+++ b/include/nps_uw_sensors_gazebo/gazebo_ros_image_sonar.hh
@@ -130,6 +130,7 @@ namespace gazebo
     private: int ray_nAzimuthRays;
     private: int ray_nElevationRays;
     private: int plotScaler;
+    private: float sensorGain;
     protected: bool debugFlag;
 
     /// \brief CSV log writing stream for verifications

--- a/launch/sonar_tank_blueview_p900.launch
+++ b/launch/sonar_tank_blueview_p900.launch
@@ -5,9 +5,9 @@
   </include>
 
   <!-- Debugging visualizations -->
-  <node name="rqt_images" pkg="rqt_gui" type="rqt_gui" output="screen"
+  <!-- <node name="rqt_images" pkg="rqt_gui" type="rqt_gui" output="screen"
         args = "&#45;&#45;perspective-file $(find nps_uw_sensors_gazebo)/config/sonar_tank_blueview_p900_images.perspective">
-  </node>
+  </node> -->
 
   <!-- rqt_image_view for image_raw_sonar -->
   <node name="rqt_image_view_sonar" pkg="rqt_image_view"

--- a/models/blueview_p900/model.sdf
+++ b/models/blueview_p900/model.sdf
@@ -63,7 +63,8 @@
           <maxDistance>10</maxDistance>
           <constantReflectivity>true</constantReflectivity>
           <raySkips>10</raySkips>
-          <plotScaler>1</plotScaler>
+          <sensorGain>0.02</sensorGain>
+          <plotScaler>10</plotScaler>
           <writeLog>false</writeLog>
           <debugFlag>false</debugFlag>
           <writeFrameInterval>5</writeFrameInterval>

--- a/src/gazebo_ros_image_sonar.cpp
+++ b/src/gazebo_ros_image_sonar.cpp
@@ -489,6 +489,7 @@ void NpsGazeboRosImageSonar::OnNewDepthFrame(const float *_image,
     // Deactivate if no subscribers
     if (this->depth_image_connect_count_ <= 0 &&
         this->point_cloud_connect_count_ <= 0 &&
+        this->sonar_image_connect_count_ <= 0 &&
         (*this->image_connect_count_) <= 0)
     {
       this->parentSensor->SetActive(false);
@@ -500,7 +501,8 @@ void NpsGazeboRosImageSonar::OnNewDepthFrame(const float *_image,
       this->ComputePointCloud(_image);
 
       // Generate sonar image data if topics have subscribers
-      if (this->depth_image_connect_count_ > 0)
+      if (this->depth_image_connect_count_ > 0 ||
+          this->sonar_image_connect_count_ > 0) {
         this->ComputeSonarImage(_image);
     }
   }


### PR DESCRIPTION
This is a new branch on the original repo concerning https://github.com/Field-Robotics-Lab/nps_uw_sensors_gazebo/pull/37 which is made on forked repo

@lauralindzey I made some generic fixes on this subject. 
- Remove duplicate sonar image publisher
- Remove sonar topic connection counter
- Make it recognize sonar topic connection as a depth camera topic connection
It was originated from the duplicate publishers of sonar image. I've removed one of them. Also removed sonar image counters which could not be utilized. The parent depth plugin code of the gazebo only has new depth image detection child functions. I have connected the new sonar image topic connection direct to the new depth image connection.