### PR TITLE
Fix docker file after Nvidia's repository update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
           repository: Field-Robotics-Lab/gtri_based_sonar
           path: gtri_based_sonar
 
+      - name: Checkout UW APL acoustic_msgs
+        uses: actions/checkout@v2
+        with:
+          repository: apl-ocean-engineering/acoustic_msgs 
+          path: acoustic_msgs
+
       - name: Checkout nps underwater sensors
         uses: actions/checkout@v2
         with:
@@ -60,12 +66,6 @@ jobs:
         with:
           repository: uuvsimulator/eca_a9
           path: eca_a9
-
-      - name: Checkout UW APL acoustic_msgs
-        uses: actions/checkout@v2
-        with:
-          repository: apl-ocean-engineering/acoustic_msgs 
-          path: acoustic_msgs
 
       - name: Set up workspace
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update \
         gnupg2 \
         curl \
         ca-certificates \
+        module-init-tools \
  && apt-get clean
 
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -94,25 +95,26 @@ ENV NCCL_VERSION 2.7.8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        nvidia-cuda-toolkit \
-        cuda-cudart-11-1=11.1.74-1 \
-        cuda-compat-11-1 \
-        pkg-config \
-        libglvnd-dev libglvnd-dev:i386 \
-        libgl1-mesa-dev libgl1-mesa-dev:i386 \
-        libegl1-mesa-dev libegl1-mesa-dev:i386 \
-        libgles2-mesa-dev libgles2-mesa-dev:i386 \
-        cuda-nvml-dev-11-1=11.1.74-1 \
-        cuda-command-line-tools-11-1=11.1.0-1 \
-        cuda-nvprof-11-1=11.1.69-1 \
-        libnpp-dev-11-1=11.1.1.269-1 \
-        cuda-libraries-dev-11-1=11.1.0-1 \
-        cuda-minimal-build-11-1=11.1.0-1 \
-        libcublas-dev-11-1=11.2.1.74-1 \
-        libcusparse-11-1=11.2.0.275-1 \
-        libcusparse-dev-11-1=11.2.0.275-1 \
+    cuda-cudart-11-1=11.1.74-1 \
+    cuda-compat-11-1 \
+    cuda-libraries-11-1=11.1.1-1 \
+    libnpp-11-1=11.1.2.301-1 \
+    cuda-nvtx-11-1=11.1.74-1 \
+    libcublas-11-1=11.3.0.106-1 \
+    libnccl2=$NCCL_VERSION-1+cuda11.1 \
+    cuda-nvml-dev-11-1=11.1.74-1 \
+    cuda-command-line-tools-11-1=11.1.1-1 \
+    cuda-nvprof-11-1=11.1.105-1 \
+    libnpp-dev-11-1=11.1.2.301-1 \
+    cuda-libraries-dev-11-1=11.1.1-1 \
+    cuda-minimal-build-11-1=11.1.1-1 \
+    libnccl-dev=2.7.8-1+cuda11.1 \
+    libcublas-dev-11-1=11.3.0.106-1 \
+    libcusparse-11-1=11.3.0.10-1 \
+    libcusparse-dev-11-1=11.3.0.10-1 \
     && apt-mark hold libnccl-dev \
-    && ln -s cuda-11.1 /usr/local/cuda
+    && ln -s cuda-11.1 /usr/local/cuda && \
+    rm -rf /var/lib/apt/lists/*
 
 # Required for nvidia-docker v1
 RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \


### PR DESCRIPTION
Found a problem not being able to connect host GPU from the docker container from my laptop saying `Failed to initialize NVML: Driver/library version mismatch`. The previous dockerfile works fine on the workstation at WHOI. It seems that the problem is caused by the network installation during the build using dockerfile after their update on the new CUDA 11.2 version. A new dockerfile is expected to resolve version conflicts concerning NVIDIA drivers and CUDA libraries.

@crvogt Considering the philosophy of having docker support, could you review this PR on the 20.04? I believe you have ubuntu 20.04 installed to review other PRs on Noetic support. Procedures to use the dockerfile is explained at [cuda library installation](https://github.com/Field-Robotics-Lab/dave/wiki/Multibeam-Forward-Looking-Sonar#cuda-library-installation). WARNING. Building the dockerfile could take up to an hour.