### PR TITLE
Declare dependency on nvidia-cuda

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <depend>roscpp</depend>
   <depend>rospy</depend>
   <depend>tf</depend>
+  <depend>nvidia-cuda</depend>
   <export>
     <gazebo_ros gazebo_model_path="${prefix}/models"/>
     <gazebo_ros gazebo_media_path="${prefix}"/>


### PR DESCRIPTION
Declare a dependency on nvidia-cuda. This could probably be a `build_depend` but I don't know how CUDA works well enough to know for sure that it's not also a runtime dependency.