### PR TITLE
adding lidar plugin back to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ catkin_package(
  )
 
 ## Plugins
+add_library(gazebo_ros_pulse_lidar_plugin src/gazebo_ros_pulse_lidar.cpp)
+target_link_libraries(gazebo_ros_pulse_lidar_plugin 
+                      ${GAZEBO_LIBRARIES} ${roscpp_LIBRARIES})
 
 # Install plugins
 install(


### PR DESCRIPTION
It looks like the lidar plugin was accidentally dropped off the CMakeLists.txt file at some point. I have added back the code that was there before, which resolves the error.

It may be better to do this another way or use a different naming convention. I think we can re-organize it when we decide on our new repository structure, so maybe for now that question could be postponed if it's going to be moot soon.

To test, run:

```
catkin_make
roslaunch nps_uw_sensors_gazebo uw_lidar_standalone.launch
```
Check the console output to make sure you don't see an error in red saying shared library `gazebo_ros_pulse_lidar_plugin.so`  cannot be found.

When the simulation starts, click play to unpause it. If the lidar stand swivels to face the cylinder, this problem is resolved.