### PR TITLE
Uwl plugin fix

### DIFF
--- a/src/gazebo_ros_pulse_lidar.cpp
+++ b/src/gazebo_ros_pulse_lidar.cpp
@@ -55,6 +55,17 @@ namespace gazebo
      // Store the model pointer for convenience.
      this->model = _model;
 
+     // Check whether a particular lidar namespace has been specified
+     // if not, default to uwl
+     string ns = "uwl";
+     string suffix = "";
+     if (_sdf->HasElement("robot_namespace"))
+     {
+       ns = _sdf->Get<string>("robot_namespace");
+       ROS_INFO_NAMED("pulse_lidar", "namespace = %s", robot_namespace);
+     }
+
+
      // Get the joints
      this->pan_joint = this->model->GetJoint("uwl/uwl_base_swivel_joint");
      this->tilt_joint = this->model->GetJoint("uwl/uwl_swivel_tray_joint");
@@ -92,6 +103,7 @@ namespace gazebo
        ROS_INFO_NAMED("pulse_lidar", "tilt_position = %f", tilt_position);
      }
 
+     
      // Set the joints' target positions.
      this->model->GetJointController()->SetPositionTarget(
          this->pan_joint->GetScopedName(), pan_position);

--- a/src/gazebo_ros_pulse_lidar.cpp
+++ b/src/gazebo_ros_pulse_lidar.cpp
@@ -102,7 +102,6 @@ namespace gazebo
        ROS_INFO_NAMED("pulse_lidar", "tilt_position = %f", tilt_position);
      }
 
-     
      // Set the joints' target positions.
      this->model->GetJointController()->SetPositionTarget(
          this->pan_joint->GetScopedName(), pan_position);

--- a/src/gazebo_ros_pulse_lidar.cpp
+++ b/src/gazebo_ros_pulse_lidar.cpp
@@ -57,18 +57,17 @@ namespace gazebo
 
      // Check whether a particular lidar namespace has been specified
      // if not, default to uwl
-     string ns = "uwl";
-     string suffix = "";
+     std::string ns = "uwl";
      if (_sdf->HasElement("robot_namespace"))
      {
-       ns = _sdf->Get<string>("robot_namespace");
-       ROS_INFO_NAMED("pulse_lidar", "namespace = %s", robot_namespace);
+       ns = _sdf->Get<std::string>("robot_namespace");
+       ROS_INFO_NAMED("pulse_lidar", "lidar namespace = %s", ns.c_str());
      }
 
 
      // Get the joints
-     this->pan_joint = this->model->GetJoint("uwl/uwl_base_swivel_joint");
-     this->tilt_joint = this->model->GetJoint("uwl/uwl_swivel_tray_joint");
+     this->pan_joint = this->model->GetJoint(ns + "/uwl_base_swivel_joint");
+     this->tilt_joint = this->model->GetJoint(ns + "/uwl_swivel_tray_joint");
 
      // Setup a P-controller, with _imax = 1
      this->pan_pid = common::PID(1, 0, 2.5, 1);


### PR DESCRIPTION
Fixes [dave repository issue #65](https://github.com/Field-Robotics-Lab/dave/issues/65). To test:

1. Run catkin_make with the changes from the `uwl_plugin_fix` branch.
2. Open the file `src/nps_uw_sensors_gazebo/urdf/uw_lidar_pedestal_robot.xacro` in a text editor.
2. Change the value of `namespace` in the `uwl_macro` element from `uwl` to `blahblah`
3. Run:
```
roslaunch nps_uw_sensors_gazebo uw_lidar_standalone.launch
```
4. Unpause to verify that the lidar mount still swivels.
5. Alternately, look through the INFO messages to verify you see "lidar namespace = blahblah"